### PR TITLE
Fix after update hook not being invoked

### DIFF
--- a/src/gverse/gverse.ts
+++ b/src/gverse/gverse.ts
@@ -104,9 +104,12 @@ namespace Gverse {
         mu.setCommitNow(this.autoCommit)
         mu.setSetJson(values)
         const uidMap = await this.txn.mutate(mu)
-        const createdUid = uidMap.getUidsMap().get("blank-0")
-        log(`Transaction ${this.uuid} mutated with new uid`, createdUid)
-        return createdUid
+        const updatedUid = uidMap.getUidsMap().get("blank-0") || values.uid
+        if (!updatedUid) {
+          return values.uid
+        }
+        log(`Transaction ${this.uuid} mutated with new uid`, updatedUid)
+        return updatedUid
       } catch (e) {
         log(e)
         try {

--- a/src/test/integration/vertex.test.ts
+++ b/src/test/integration/vertex.test.ts
@@ -132,29 +132,35 @@ describe("Vertex", () => {
   })
   describe("hooks", () => {
     it("calls before and after create", async () => {
-      expect(pet.beforeCreatedSet).toBe(true)
-      expect(pet.afterCreateSet).toBe(true)
+      let pet = new Pet()
+      expect(pet.beforeCreateSet).toBe(false)
+      expect(pet.afterCreateSet).toBe(false)
+      pet = (await graph.create(pet)) as Pet
+      await graph.save(pet) // apply afterCreate
       const petFromGraph = (await pet.loadFrom(graph)) as Pet
-      if (!petFromGraph) fail("Not found")
-      else expect(petFromGraph.beforeCreatedSet).toBe(true)
+      expect(petFromGraph).toBeDefined()
+      expect(petFromGraph.beforeCreateSet).toBe(true)
+      expect(petFromGraph.afterCreateSet).toBe(true)
     })
+
     it("calls before and after update", async () => {
-      expect(pet.beforeUpdateSet).toBe(false) // precondition
+      expect(pet.beforeUpdateSet).toBe(false)
       pet.name = "Garfield"
-      await pet.saveInto(graph)
+      await pet.saveInto(graph) // apply beforeUpdate
+      await pet.saveInto(graph) // apply afterUpdate
       const petFromGraph = (await pet.loadFrom(graph)) as Pet
-      if (!petFromGraph) fail("Not found")
-      else expect(petFromGraph.beforeUpdateSet).toBe(true)
+      expect(petFromGraph).toBeDefined()
+      expect(petFromGraph.beforeUpdateSet).toBe(true)
+      expect(petFromGraph.afterUpdateSet).toBe(true)
     })
+
     it("calls before and after delete", async () => {
-      expect(pet.beforeDeleteSet).toBe(false) // precondition
-      expect(pet.afterDeleteSet).toBe(false) // precondition
+      expect(pet.beforeDeleteSet).toBe(false)
+      expect(pet.afterDeleteSet).toBe(false)
       let deletedPet = await pet.deleteFrom(graph)
-      if (!deletedPet) fail("Can not be deleted")
-      else {
-        expect(pet.beforeDeleteSet).toBeTruthy()
-        expect(pet.afterDeleteSet).toBeTruthy()
-      }
+      expect(deletedPet).toBeDefined()
+      expect(pet.beforeDeleteSet).toBe(true)
+      expect(pet.afterDeleteSet).toBe(true)
     })
   })
   describe("language support", () => {

--- a/src/test/integration/vertex_fixtures.ts
+++ b/src/test/integration/vertex_fixtures.ts
@@ -15,7 +15,7 @@ export class Pet extends Gverse.Vertex {
   breed: string = ""
   origin?: Origin
   owner?: Owner
-  beforeCreatedSet = false
+  beforeCreateSet = false
   afterCreateSet = false
   beforeUpdateSet = false
   afterUpdateSet = false
@@ -44,7 +44,7 @@ export class Pet extends Gverse.Vertex {
     return updated as Pet
   }
   async beforeCreate() {
-    this.beforeCreatedSet = true
+    this.beforeCreateSet = true
   }
   async afterCreate() {
     this.afterCreateSet = true
@@ -61,6 +61,9 @@ export class Pet extends Gverse.Vertex {
   async afterDelete() {
     this.afterDeleteSet = true
   }
+  // async loadFrom(graph: Gverse.Graph): Promise<Pet> {
+  //   return graph.load(this) as Pet
+  // }
 }
 
 export class Owner extends Gverse.Vertex {


### PR DESCRIPTION
Fix update hook when mutating an existing uid. Dgraph does not return the uid unless new vertex was created.