### PR TITLE
Reduced depth to 1 if traverse is false in graph.update

### DIFF
--- a/src/gverse/graph.ts
+++ b/src/gverse/graph.ts
@@ -253,7 +253,7 @@ export class Graph {
     log("Graph.save", vertex)
     if (!vertex.uid) throw "Can not save a vertex without a uid"
     const tx = transaction || this.connection.newTransaction(true)
-    const currentValues = await this.uid(vertex.uid, tx, 3)
+    const currentValues = await this.uid(vertex.uid, tx, traverse ? 3 : 1)
     await vertex.beforeUpdate(currentValues, vertex.marshal(traverse))
 
     // marshal again to get any updated values from beforeUpdate


### PR DESCRIPTION
`graph.update` is querying the vertex with depth 3 even if traverse is false. Which is making update slower for vertices having huge data. 
This PR is reducing the depth to 1 if traverse is false.