### PR TITLE
Added upsert support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,4 +35,5 @@ jobs:
           name: Set up integration test environment
           command: |
             set -x
+            export COMPOSE_TLS_VERSION=TLSv1_2
             docker-compose -f src/test/integration/docker-compose.yml up --build --exit-code-from gverse --abort-on-container-exit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
       # run unit tests
       - run: yarn test
 
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
 
       # run integration tests
       - run:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ class Repo {
 
 Edges can be directed or undirected (reversible), and can have a cardinality of one or many. For detailed examples, please see the integration tests under `./test/integration`.
 
+#### Running upsert (query with mutation)
+
+The `graph.newTransaction().upsert` method enables you to execute upsert block having a query and a mutation:
+
+```
+const query = `{vertex as var(func: eq(name,"John"))}`
+const values = {
+  uid: "uid(vertex)",
+  name: "Smith"
+}
+await graph.newTransaction().upsert(query, values)
+```
+
+An optional parameter `condition` can be used to run a conditional upsert:
+
+```
+const condition = `eq(len(vertex), 1)`
+await graph.newTransaction().upsert(query, values, condition)
+```
+
 ### Running Tests
 
 Test coverage for Gverse comes from integration tests. [Docker](https://docs.docker.com/install/) and [Docker-Compose](https://docs.docker.com/compose/install/) are required for running integration tests.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Edges can be directed or undirected (reversible), and can have a cardinality of 
 
 The `graph.newTransaction().upsert` method enables you to execute upsert block having a query and a mutation:
 
-```
+```typescript
 const query = `{vertex as var(func: eq(name,"John"))}`
 const values = {
   uid: "uid(vertex)",
@@ -143,7 +143,7 @@ await graph.newTransaction().upsert(query, values)
 
 An optional parameter `condition` can be used to run a conditional upsert:
 
-```
+```typescript
 const condition = `eq(len(vertex), 1)`
 await graph.newTransaction().upsert(query, values, condition)
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gverse",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Object Graph Mapper for Dgraph",
   "main": "dist/gverse/index.js",
   "types": "dist/gverse/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
-    "dgraph-js": "^20.3.0",
+    "dgraph-js": "20.3.0",
     "grpc": "~1.23.3",
     "lodash": "~4.17.15",
     "ts-node": "~8.4.1",

--- a/src/test/integration/Dockerfile
+++ b/src/test/integration/Dockerfile
@@ -2,7 +2,6 @@ FROM node:12-alpine
 
 WORKDIR /usr/gverse
 
-ENV COMPOSE_TLS_VERSION=TLSv1_2
 COPY ./package.json .
 COPY ./tsconfig.json .
 COPY ./jest.integration.config.js .

--- a/src/test/integration/Dockerfile
+++ b/src/test/integration/Dockerfile
@@ -2,6 +2,7 @@ FROM node:12-alpine
 
 WORKDIR /usr/gverse
 
+ENV COMPOSE_TLS_VERSION=TLSv1_2
 COPY ./package.json .
 COPY ./tsconfig.json .
 COPY ./jest.integration.config.js .

--- a/src/test/integration/index.test.ts
+++ b/src/test/integration/index.test.ts
@@ -33,6 +33,33 @@ describe("Gverse", () => {
       const tx = conn.newTransaction(true)
       await tx.mutate({ pet: { name: "Bigglesworth", "dgraph.type": type } })
     })
+    it("runs simple upsert", async () => {
+      const tx = conn.newTransaction(true)
+      await tx.mutate({
+        pet: { name: "James Bigglesworth", "dgraph.type": type }
+      })
+
+      const query = `{vertex as var(func: type(${type})) }`
+      const values = {
+        uid: "uid(vertex)",
+        nickName: "Biggles"
+      }
+      await conn.newTransaction().upsert(query, values)
+    })
+    it("runs conditional upsert", async () => {
+      const tx = conn.newTransaction(true)
+      await tx.mutate({
+        pet: { name: "James Bigglesworth", "dgraph.type": type }
+      })
+
+      const query = `{vertex as var(func: type(${type})) }`
+      const values = {
+        uid: "uid(vertex)",
+        nickName: "Biggles"
+      }
+      const condition = `eq(len(vertex), 1)`
+      await conn.newTransaction().upsert(query, values, condition)
+    })
     it("queries", async () => {
       const tx = conn.newTransaction(true)
       await tx.mutate({ pet: { name: "Biggles", "dgraph.type": type } })


### PR DESCRIPTION
- Added version for fixing circle CI issue ([ref](https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-))
- Added tlsv1_2 in config.yml ([ref](https://github.com/docker/compose/issues/6473))
- Restricted dgraph-js to 20.3.0 due to grpc Channel credentials bug